### PR TITLE
Reverse path for posframe labels

### DIFF
--- a/ace-window-posframe.el
+++ b/ace-window-posframe.el
@@ -4,7 +4,7 @@
 
 (defun aw--lead-overlay-posframe (path leaf)
   (let* ((wnd (cdr leaf))
-         (str (format "%s" (apply #'string path)))
+         (str (format "%s" (apply #'string (reverse path))))
          ;; It's important that buffer names are not unique across
          ;; multiple invocations: posframe becomes very slow when
          ;; creating new frames, and so being able to reuse old ones
@@ -12,7 +12,7 @@
          ;; something like: a frame exists which hasn't been deleted
          ;; (with posframe-delete) and has the same configuration as
          ;; the requested new frame.
-         (bufname (format "*aw-posframe-buffer-%s*" path)))
+         (bufname (format "*aw-posframe-buffer-%s*" str)))
     (with-selected-window wnd
       (push bufname aw--posframe-frames)
       (posframe-show bufname


### PR DESCRIPTION
A correction for a rare edge case where the path is shown in the reverse order for multichar labels. The original ace-window functions feature this `(reverse path)` pattern. Thanks and I hope this gets merged!